### PR TITLE
Add payload to reporting class render data

### DIFF
--- a/middleware/reporting.js
+++ b/middleware/reporting.js
@@ -253,6 +253,10 @@ module.exports = function (context, params) {
 			}
 		});
 
+		if(params.payload) {
+			data = Object.assign(data, params.payload);
+		}
+
 		let name = data[params.key_field || 'id'];
 		let fileGroup = params.group || 'misc';
 
@@ -301,9 +305,10 @@ module.exports = function (context, params) {
 		await browser.close();
 
 		return {
-			name  : name,
-			group : fileGroup,
-			size  : anxeb.utils.file.stats(reportFilePath).size
+			name    : name,
+			group   : fileGroup,
+			path    : reportFilePath,
+			size    : anxeb.utils.file.stats(reportFilePath).size
 		}
 	}
 


### PR DESCRIPTION
We also added the path of the file generated
in order to be able to read it later on. (if needed)